### PR TITLE
Only try renaming if >0 columns are selected

### DIFF
--- a/R/dat_checks.R
+++ b/R/dat_checks.R
@@ -37,8 +37,8 @@ convert_region_size <- function(region_size){
 
 dat_column_chr_pos_check <- function(df){
   df <- df %>% 
-    rename_with(~ "CHROM", matches(c("^chrom$","^chr$","^chromosome$"), ignore.case = TRUE)) %>% 
-    rename_with(~ "POS", matches(c("^pos$","^bp$","^base_pair_location$"), ignore.case = TRUE))
+    rename_with(~ rename_value(.x, "CHROM"), matches(c("^chrom$","^chr$","^chromosome$"), ignore.case = TRUE)) %>% 
+    rename_with(~ rename_value(.x, "POS"), matches(c("^pos$","^bp$","^base_pair_location$"), ignore.case = TRUE))
   return(df)
 }
 
@@ -49,19 +49,19 @@ dat_column_check_and_set <- function(dat, verbose=TRUE,locuszoomplot=FALSE){
     if(locuszoomplot)
       dfwithcolor=df
     df <- df %>% 
-      dplyr::rename_with(~ "ID", matches(c("^rsid$","^rsname$","^snp$"), ignore.case = TRUE)) %>% 
-      dplyr::rename_with(~ "Gene_Symbol", matches(c("^gene_symbol$","^gene$","^genename$","^gene_name$"), ignore.case = TRUE)) %>%
-      dplyr::rename_with(~ "Max_Impact", matches(c("^max_impact$","^impact$"), ignore.case = TRUE)) %>% 
-      dplyr::rename_with(~ "OR", matches(c("^odds_ratio$","^or$"), ignore.case = TRUE)) %>% 
-      dplyr::rename_with(~ "BETA", matches(c("^beta$"), ignore.case=TRUE)) %>% 
-      dplyr::rename_with(~ "REF", matches(c("^ref$"), ignore.case=TRUE)) %>% 
-      dplyr::rename_with(~ "ALT", matches(c("^alt$"), ignore.case=TRUE)) 
+      dplyr::rename_with(~ rename_value(.x, "ID"), matches(c("^rsid$","^rsname$","^snp$"), ignore.case = TRUE)) %>% 
+      dplyr::rename_with(~ rename_value(.x, "Gene_Symbol"), matches(c("^gene_symbol$","^gene$","^genename$","^gene_name$"), ignore.case = TRUE)) %>%
+      dplyr::rename_with(~ rename_value(.x, "Max_Impact"), matches(c("^max_impact$","^impact$"), ignore.case = TRUE)) %>% 
+      dplyr::rename_with(~ rename_value(.x, "OR"), matches(c("^odds_ratio$","^or$"), ignore.case = TRUE)) %>% 
+      dplyr::rename_with(~ rename_value(.x, "BETA"), matches(c("^beta$"), ignore.case=TRUE)) %>% 
+      dplyr::rename_with(~ rename_value(.x, "REF"), matches(c("^ref$"), ignore.case=TRUE)) %>% 
+      dplyr::rename_with(~ rename_value(.x, "ALT"), matches(c("^alt$"), ignore.case=TRUE)) 
     if(locuszoomplot)
         df$color <- dfwithcolor$color
    
     if(! "P" %in% colnames(df)){
       df <- df %>% 
-        dplyr::rename_with(~ "P", matches(c("^pval$","^pvalue$","^p_value$","^p$"), ignore.case = TRUE)) 
+        dplyr::rename_with(~ rename_value(.x, "P"), matches(c("^pval$","^pvalue$","^p_value$","^p$"), ignore.case = TRUE)) 
     }
     if(! "ID" %in% colnames(df)){
       if("CHROM" %in% colnames(df)){

--- a/R/miscellaneous.R
+++ b/R/miscellaneous.R
@@ -39,3 +39,11 @@ is_df_empty <- function(df, type){
     }
   }
 }
+
+rename_value <- function(x, value) {
+  if (length(x) == 0L) {
+    character()
+  } else {
+    value
+  }
+}


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

`rename_with()` now checks that the length of the function result matches the length of the input (i.e. if 2 columns need to be renamed it should return a vector of length 2). We need to adjust your code to account for the case when 0 columns need to be renamed.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!