### PR TITLE
due to new changes to get_lead_snps, flank_size & region_size are the same

### DIFF
--- a/R/manhattan.R
+++ b/R/manhattan.R
@@ -305,8 +305,7 @@ manhattan <- function(df, ntop=4, title="",annotate=NULL, color=NULL,
 #' @param df Dataframe, GWAS summary statistics
 #' @param genome_wide_thresh A number. P-value threshold for genome wide significant loci (5e-08 by default)
 #' @param suggestive_thresh A number. P-value threshold for suggestive loci (1e-06 by default)
-#' @param flank_size A number (default = 5000). The size of the flanking region for the significant and suggestitve snps.
-#' @param region_size An integer (default = 1000000) (or a string represented as 200kb or 2MB) indicating the window size for variant labeling. Increase this number for sparser annotation and decrease for denser annotation.
+#' @param flank_size A number (default = 1e6). The size of the flanking region for the significant and suggestitve snps.
 #' @param ymax Integer, max of the y-axis, (default value: \code{ymax=(max(-log10(df$P)) + max(-log10(df$P)) * .2))}
 #' @param ... Additional arguments passed to other plotting functions.
 #' @inheritParams manhattan
@@ -321,7 +320,7 @@ manhattan <- function(df, ntop=4, title="",annotate=NULL, color=NULL,
 #' 
 
 
-manhattanExtra <- function(df,genome_wide_thresh=5e-08, suggestive_thresh=1e-06, flank_size=1e6, region_size=1e7, sign_thresh_color=NULL, sign_thresh_label_size=NULL, show_legend=TRUE,label_fontface=NULL,
+manhattanExtra <- function(df,genome_wide_thresh=5e-08, suggestive_thresh=1e-06, flank_size=1e6, sign_thresh_color=NULL, sign_thresh_label_size=NULL, show_legend=TRUE,label_fontface=NULL,
                            nudge_y=NULL, ymax=NULL, sign_thresh=NULL, label_color=NULL, color=NULL, legend_labels=NULL, annotate=NULL, ...){
  
    if(!is.data.frame(df) && is.list(df)){
@@ -330,7 +329,7 @@ manhattanExtra <- function(df,genome_wide_thresh=5e-08, suggestive_thresh=1e-06,
       df <- as.data.frame(df[1])
     }
   
-  top_signals <- get_sign_and_sugg_loci(df, genome_wide_thresh = genome_wide_thresh, suggestive_thresh = suggestive_thresh, flank_size = flank_size, region_size = region_size)
+  top_signals <- get_sign_and_sugg_loci(df, genome_wide_thresh = genome_wide_thresh, suggestive_thresh = suggestive_thresh, flank_size = flank_size)
   if(is.null(color))
     color <- c("grey80", "#0072B2","#D55E00")
   if(is.null(annotate))
@@ -369,7 +368,7 @@ manhattanExtra <- function(df,genome_wide_thresh=5e-08, suggestive_thresh=1e-06,
   }
   manh <- manhattan(dat,
                     annotate = annotate[index],
-                    region_size = region_size,
+                    region_size = flank_size,
                     color = color[index],
                     label_color = label_color,
                     label_fontface = label_fontface,

--- a/R/setters_and_getters.R
+++ b/R/setters_and_getters.R
@@ -394,8 +394,7 @@ get_pos_with_offset <- function(df,offsets){
 #' @param df Dataframe, GWAS summary statistics
 #' @param genome_wide_thresh A number. P-value threshold for genome wide significant loci (5e-08 by default)
 #' @param suggestive_thresh A number. P-value threshold for suggestive loci (1e-06 by default)
-#' @param flank_size A number (default = 5000). The size of the flanking region for the significant and suggestitve snps.
-#' @param region_size An integer (default = 1000000) (or a string represented as 200kb or 2MB) indicating the window size for variant labeling. Increase this number for sparser annotation and decrease for denser annotation.
+#' @param flank_size A number (default = 1e6). The size of the flanking region for the significant and suggestitve snps.
 #' @return List of genome wide and suggestive loci.
 #' @export
 #' @examples
@@ -404,10 +403,10 @@ get_pos_with_offset <- function(df,offsets){
 #' }
 #'
 
-get_sign_and_sugg_loci <- function(df, genome_wide_thresh = 5e-8, suggestive_thresh = 1e-6, flank_size = 5e4, region_size=1e6) {
+get_sign_and_sugg_loci <- function(df, genome_wide_thresh = 5e-8, suggestive_thresh = 1e-6, flank_size = 1e6) {
   genome_wide_snps <- data.frame()
   suggestive_snps <- data.frame()
-  leads <- df |> get_lead_snps(thresh = suggestive_thresh, region_size = region_size, verbose = FALSE)
+  leads <- df |> get_lead_snps(thresh = suggestive_thresh, region_size = flank_size, verbose = FALSE)
    if (nrow(leads) == 0) {
     return(list(genome_wide_snps = genome_wide_snps, suggestive_snps = suggestive_snps))
   }


### PR DESCRIPTION
This fixes a new issue with the manhattanExtra function annotating strangely when flank_size and region_size were different. Needs to be locked to the same value. Fixed docstrings as well.