### PR TITLE
still allow for sparser/denser annotations with region

### DIFF
--- a/R/manhattan.R
+++ b/R/manhattan.R
@@ -330,7 +330,7 @@ manhattanExtra <- function(df,genome_wide_thresh=5e-08, suggestive_thresh=1e-06,
       df <- as.data.frame(df[1])
     }
   
-  top_signals <- get_sign_and_sugg_loci(df, genome_wide_thresh = genome_wide_thresh, suggestive_thresh = suggestive_thresh, flank_size = flank_size)
+  top_signals <- get_sign_and_sugg_loci(df, genome_wide_thresh = genome_wide_thresh, suggestive_thresh = suggestive_thresh, flank_size = flank_size, region_size = region_size)
   if(is.null(color))
     color <- c("grey80", "#0072B2","#D55E00")
   if(is.null(annotate))

--- a/R/manhattan.R
+++ b/R/manhattan.R
@@ -306,6 +306,7 @@ manhattan <- function(df, ntop=4, title="",annotate=NULL, color=NULL,
 #' @param genome_wide_thresh A number. P-value threshold for genome wide significant loci (5e-08 by default)
 #' @param suggestive_thresh A number. P-value threshold for suggestive loci (1e-06 by default)
 #' @param flank_size A number (default = 1e6). The size of the flanking region for the significant and suggestitve snps.
+#' @param region_size A number (default = 1e6). The size of the region for gene annotation. Increase this number for sparser annotation and decrease for denser annotation.
 #' @param ymax Integer, max of the y-axis, (default value: \code{ymax=(max(-log10(df$P)) + max(-log10(df$P)) * .2))}
 #' @param ... Additional arguments passed to other plotting functions.
 #' @inheritParams manhattan
@@ -320,7 +321,7 @@ manhattan <- function(df, ntop=4, title="",annotate=NULL, color=NULL,
 #' 
 
 
-manhattanExtra <- function(df,genome_wide_thresh=5e-08, suggestive_thresh=1e-06, flank_size=1e6, sign_thresh_color=NULL, sign_thresh_label_size=NULL, show_legend=TRUE,label_fontface=NULL,
+manhattanExtra <- function(df,genome_wide_thresh=5e-08, suggestive_thresh=1e-06, flank_size=1e6, region_size=1e6, sign_thresh_color=NULL, sign_thresh_label_size=NULL, show_legend=TRUE,label_fontface=NULL,
                            nudge_y=NULL, ymax=NULL, sign_thresh=NULL, label_color=NULL, color=NULL, legend_labels=NULL, annotate=NULL, ...){
  
    if(!is.data.frame(df) && is.list(df)){
@@ -368,7 +369,7 @@ manhattanExtra <- function(df,genome_wide_thresh=5e-08, suggestive_thresh=1e-06,
   }
   manh <- manhattan(dat,
                     annotate = annotate[index],
-                    region_size = flank_size,
+                    region_size = region_size,
                     color = color[index],
                     label_color = label_color,
                     label_fontface = label_fontface,

--- a/R/setters_and_getters.R
+++ b/R/setters_and_getters.R
@@ -395,6 +395,7 @@ get_pos_with_offset <- function(df,offsets){
 #' @param genome_wide_thresh A number. P-value threshold for genome wide significant loci (5e-08 by default)
 #' @param suggestive_thresh A number. P-value threshold for suggestive loci (1e-06 by default)
 #' @param flank_size A number (default = 1e6). The size of the flanking region for the significant and suggestitve snps.
+#' @param region_size A number (default = 1e6). The size of the region for top snp search. Only one snp per region is returned.
 #' @return List of genome wide and suggestive loci.
 #' @export
 #' @examples
@@ -403,10 +404,10 @@ get_pos_with_offset <- function(df,offsets){
 #' }
 #'
 
-get_sign_and_sugg_loci <- function(df, genome_wide_thresh = 5e-8, suggestive_thresh = 1e-6, flank_size = 1e6) {
+get_sign_and_sugg_loci <- function(df, genome_wide_thresh = 5e-8, suggestive_thresh = 1e-6, flank_size = 1e6, region_size = 1e6) {
   genome_wide_snps <- data.frame()
   suggestive_snps <- data.frame()
-  leads <- df |> get_lead_snps(thresh = suggestive_thresh, region_size = flank_size, verbose = FALSE)
+  leads <- df |> get_lead_snps(thresh = suggestive_thresh, region_size = region_size, verbose = FALSE)
    if (nrow(leads) == 0) {
     return(list(genome_wide_snps = genome_wide_snps, suggestive_snps = suggestive_snps))
   }


### PR DESCRIPTION
Pull this down and check it out. My fix went too far, I was mostly addressing the usage of region_size in the setter_getter fucntion. region_size should only be used in manhattan for annotation density.